### PR TITLE
Bugfix - Repository name fix for plugin.video.filmon.simple player and minor navigation regex fix

### DIFF
--- a/navigate.filmonsimple.cy.metalliq.json
+++ b/navigate.filmonsimple.cy.metalliq.json
@@ -29,7 +29,7 @@
         "link":"plugin://plugin.video.filmon.simple/",
         "steps":[
           "@any",
-          "{name}"
+          ".*{name}.*"
         ],
         "action":"PLAY"
       },

--- a/navigate.filmonsimple.cy.metalliq.json
+++ b/navigate.filmonsimple.cy.metalliq.json
@@ -1,6 +1,6 @@
 {
   "name":"Navigate [COLOR FF0084FF]-[/COLOR] FilmOn Simple ([COLOR FF0084FF]Cy[/COLOR])",
-  "repository":"repository.xmbchub",
+  "repository":"repository.xbmchub",
   "plugin":"plugin.video.filmon.simple",
   "priority":800,
   "id":"navigate.filmonsimple.cy",


### PR DESCRIPTION
Fixes to Metalliq player for `plugin.video.filmon.simple`

* Fixes download of `repository.xbmchub` when player is triggered via TV Portal's automated addon installer.
* Minor fix to regex for "live tv channels containing name" navigation.
